### PR TITLE
Update friends link to new URL

### DIFF
--- a/src/pages/friends/index.astro
+++ b/src/pages/friends/index.astro
@@ -131,7 +131,7 @@ Astro.locals.noscript = true;
     />
     <Card
       title="dpkg123 的博客"
-      link="dpkg123.site"
+      link="dpkg123.top"
       avatar="//dpkg123.site/favicon.jpg"
       feed="https://dpkg123.netlify.app/atom.xml"
       desc="路漫漫其修远兮，吾将上下而求索。"


### PR DESCRIPTION
Update the link for "dpkg123 的博客" in `src/pages/friends/index.astro`.

* Change the `link` attribute of the `Card` component for "dpkg123 的博客" to `dpkg123.top`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OverflowCat/blog/pull/911?shareId=72b3b771-16cd-47b2-bf74-954d884e580d).